### PR TITLE
Event Emitter App crash fix

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/EventEmitter.java
@@ -57,41 +57,59 @@ public class EventEmitter {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendNavigatorEvent(eventId, navigatorEventId);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendNavigatorEvent(eventId, navigatorEventId);
+        }
     }
 
     public void sendNavigatorEvent(String eventId, String navigatorEventId, WritableMap data) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendNavigatorEvent(eventId, navigatorEventId, data);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendNavigatorEvent(eventId, navigatorEventId, data);
+        }
     }
 
     public void sendEvent(String eventId, String navigatorEventId) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, navigatorEventId);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, navigatorEventId);
+        }
     }
 
     public void sendNavigatorEvent(String eventId, WritableMap arguments) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, arguments);
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, arguments);
+        }
     }
 
     public void sendEvent(String eventId) {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent(eventId, Arguments.createMap());
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent(eventId, Arguments.createMap());
+        }
     }
 
     public void sendAppLaunchedEvent() {
         if (!NavigationApplication.instance.isReactContextInitialized()) {
             return;
         }
-        reactGateway.getReactEventEmitter().sendEvent("RNN.appLaunched", Arguments.createMap());
+        NavigationReactEventEmitter emitter = reactGateway.getReactEventEmitter();
+        if (emitter != null) {
+            emitter.sendEvent("RNN.appLaunched", Arguments.createMap());
+        }
     }
 }


### PR DESCRIPTION
- Fixing the Error
`EventEmitter.java line 72 com.reactnativenavigation.bridge.EventEmitter.sendNavigatorEvent`
- Reffered from this [fix](https://github.com/wix/react-native-navigation/issues/3100).