### PR TITLE
PermissionsModule over ride clearHostOnActivityDestroy

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
+++ b/android/app/src/main/java/com/reactnativenavigation/NavigationApplication.java
@@ -53,6 +53,11 @@ public abstract class NavigationApplication extends Application implements React
         }
     }
 
+    @Override
+    public boolean clearHostOnActivityDestroy() {
+        return false;
+    }
+
     public void startReactContextOnceInBackgroundAndExecuteJS() {
         reactGateway.startReactContextOnceInBackgroundAndExecuteJS();
     }


### PR DESCRIPTION
- Overriding `clearHostOnActivityDestroy` and returning false in mainApplication.java.
- Referring https://github.com/wix/react-native-navigation/pull/2043